### PR TITLE
add a delay when the connection attempt fails

### DIFF
--- a/src/uSynergy.c
+++ b/src/uSynergy.c
@@ -831,8 +831,12 @@ void uSynergyUpdate(uSynergyContext *context)
 				Exit(context->m_lastError);
 			}
 		}
-		if (context->m_connectFunc(context->m_cookie))
+		if (context->m_connectFunc(context->m_cookie)) {
 			context->m_connected = true;
+		} else {
+			logErr("Connection attempt failed, trying to reconnect in a second");
+			context->m_sleepFunc(context->m_cookie, 1000);
+		}
 	}
 }
 


### PR DESCRIPTION
Per #12, when the connection immediately fails there is currently no
delay in trying again, resulting in excessive CPU usage while spinning
on the non-existent network. This adds the one second delay that
accompanies other failures to hopefully make this more manageable.