### PR TITLE
Fix right alt mapping for Windows primaries

### DIFF
--- a/doc/xkb/keycodes/win
+++ b/doc/xkb/keycodes/win
@@ -93,7 +93,7 @@ default xkb_keycodes "win" {
     <LWIN> = 354;
     <LALT> = 0x3f;
     <SPCE> = 0x40;
-    <RALT> = 319;
+    <LVL3> = 319; // Right Alt
     <RWIN> = 0x203;
     <MENU> = 356;
     <RCTL> = 292;


### PR DESCRIPTION
Mod5 modifier required to type accented characters is mapped to LVL3 to which RALT is mapped on keyboards layout that use it.
Without this change I wasn't able to use Polish characters (all characters that require holding right alt) on Linux client running swaywm.
I bet that this is an unclean way to implement it. I'm just putting it out here for anyone that might need it and/or for someone to actually implement it right.