### PR TITLE
support mixing maps of synergy and raw keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,19 @@ The offset functionality is enabled through `raw-keymap/offset`, though it
 can also be disabled for explicit mappings by setting `raw-keymap/offset_on_explicit`
 to `false`. 
 
+###### Synergy ID keymapping
+
+In some cases (see recent comments on #35) Windows servers are sending 
+duplicate button values for keys which are clearly different. In these cases
+using the synergy key IDs might make sense in an `id-keymap` section:
+```
+[id-keymap]
+57218 = 199
+57219 = 200
+```
+with actual values based on the above process, using the `id` parameter in the
+server log instead of `button`.
+
 #### Screensaver
 
 `screensaver/start` should contain a command to be run when the screensaver is
@@ -247,8 +260,9 @@ it when it is deactivated.
 
 Due to issues with the idle inhibition protocol, idle is actually inhibited by
 sending a hopefully-meaningless event to the compositor: if `idle-inhibit/method`
-is `key`, the key associated with the xkb-style name in `idle-inhibit/keyname` is
-pressed (defaults to `HYPR`). If `idle-inhbibit/method` is `mouse`, then a relative 
+is `key`, the raw keycode given in `idle-inhibit/keycode` is sent if defined, 
+falling back on the xkb-style key name in `idle-inhibit/keyname`, which will
+default to `HYPR`. If `idle-inhbibit/method` is `mouse`, then a relative 
 move of 0,0 is sent (this is the default). 
 
 The mouse approach prevents any clashes with keys, but will prevent cursor

--- a/include/uSynergy.h
+++ b/include/uSynergy.h
@@ -261,11 +261,12 @@ This callback is called when a key is pressed or released.
 
 @param cookie		Cookie supplied in the Synergy context
 @param key			Key code of key that was pressed or released
+@param id 		Synergy key ID code of the key that was pressed or released
 @param modifiers	Status of modifier keys (alt, shift, etc.)
 @param down			Down or up status, 1 is key is pressed down, 0 if key is released (up)
 @param repeat		Repeat flag, 1 if the key is down because the key is repeating, 0 if the key is initially pressed by the user
 **/
-typedef void		(*uSynergyKeyboardCallback)(uSynergyCookie cookie, uint16_t key, uint16_t modifiers, bool down, bool repeat);
+typedef void		(*uSynergyKeyboardCallback)(uSynergyCookie cookie, uint16_t key, uint16_t id, uint16_t modifiers, bool down, bool repeat);
 
 
 

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -44,12 +44,18 @@ struct wlInput {
 	/* key state information*/
 	int *key_press_state;
 	size_t key_count;
+	int *id_press_state;
+	size_t id_count;
 	// keyboard layout handling
 	struct xkb_context *xkb_ctx;
 	struct xkb_keymap *xkb_map;
 	struct xkb_state *xkb_state;
 	/* raw keymap -- distinct from xkb */
 	int *raw_keymap;
+	/* id-based keymap -- uses synergy abstract keycodes */
+	int *id_keymap;
+	/* whether or not a given id entry should be used */
+	bool *id_keymap_valid;
 	/* wayland context */
 	struct wlContext *wl_ctx;
 	/* actual functions */
@@ -119,7 +125,8 @@ extern void wlMouseButtonUp(struct wlContext *context, int button);
 extern void wlMouseWheel(struct wlContext *context, signed short dx, signed short dy);
 
 /* keyboard-related functions */
-extern void wlKey(struct wlContext *context, int key, int state);
+extern void wlKeyRaw(struct wlContext *context, int key, int state);
+extern void wlKey(struct wlContext *context, int key, int id, int state);
 /* release all currently-pressed keys, usually on exiting the screen */
 extern void wlKeyReleaseAll(struct wlContext *context);
 

--- a/src/main.c
+++ b/src/main.c
@@ -67,10 +67,10 @@ static void syn_mouse_move_cb(uSynergyCookie cookie, bool rel, int16_t x, int16_
 		wlMouseMotion(&wlContext, x, y);
 	}
 }
-static void syn_key_cb(uSynergyCookie cookie, uint16_t key, uint16_t mod, bool down, bool repeat)
+static void syn_key_cb(uSynergyCookie cookie, uint16_t key, uint16_t id, uint16_t mod, bool down, bool repeat)
 {
 	if (!repeat)
- 		wlKey(&wlContext, key, down);
+ 		wlKey(&wlContext, key, id, down);
 }
 static void syn_clip_cb(uSynergyCookie cookie, enum uSynergyClipboardId id, uint32_t format, const uint8_t *data, uint32_t size)
 {

--- a/src/uSynergy.c
+++ b/src/uSynergy.c
@@ -204,14 +204,14 @@ static void sSendScreensaverCallback(uSynergyContext *context, bool state)
 /**
 @brief Send keyboard callback when a key has been pressed or released
 **/
-static void sSendKeyboardCallback(uSynergyContext *context, uint16_t key, uint16_t modifiers, bool down, bool repeat)
+static void sSendKeyboardCallback(uSynergyContext *context, uint16_t key, uint16_t id, uint16_t modifiers, bool down, bool repeat)
 {
 	// Skip if no callback is installed
 	if (context->m_keyboardCallback == 0L)
 		return;
 
 	// Send callback
-	context->m_keyboardCallback(context->m_cookie, key, modifiers, down, repeat);
+	context->m_keyboardCallback(context->m_cookie, key, id, modifiers, down, repeat);
 }
 
 
@@ -496,7 +496,7 @@ static void sProcessMessage(uSynergyContext *context, struct sspBuf *msg)
 		if (!(sspNetU16(msg, &id) && sspNetU16(msg, &mod) && sspNetU16(msg, &key))) {
 			PARSE_ERROR();
 		}
-		sSendKeyboardCallback(context, context->m_useRawKeyCodes ? key : id, mod, true, false);
+		sSendKeyboardCallback(context, context->m_useRawKeyCodes ? key : id, id, mod, true, false);
 	}
 	else if (!strcmp(pkt_id, "DKRP"))
 	{
@@ -510,7 +510,7 @@ static void sProcessMessage(uSynergyContext *context, struct sspBuf *msg)
 		      sspNetU16(msg, &key))) {
 			PARSE_ERROR();
 		}
-		sSendKeyboardCallback(context, context->m_useRawKeyCodes ? key : id, mod, true, true);
+		sSendKeyboardCallback(context, context->m_useRawKeyCodes ? key : id, id, mod, true, true);
 	}
 	else if (!strcmp(pkt_id, "DKUP"))
 	{
@@ -521,7 +521,7 @@ static void sProcessMessage(uSynergyContext *context, struct sspBuf *msg)
 		if (!(sspNetU16(msg, &id) && sspNetU16(msg, &mod) && sspNetU16(msg, &key))) {
 			PARSE_ERROR();
 		}
-		sSendKeyboardCallback(context, context->m_useRawKeyCodes ? key : id, mod, false, false);
+		sSendKeyboardCallback(context, context->m_useRawKeyCodes ? key : id, id, mod, false, false);
 	}
 	else if (!strcmp(pkt_id, "DGBT"))
 	{


### PR DESCRIPTION
This should aid in fixing #35, as Windows seems to be sending identical
buttons for different keys, but distinct synergy identifiers.

Also support setting a raw keycode for idle... which goes here becuase
it will solve the problem of HYPR on uinput triggering the play key.