### PR TITLE
send larger discrete axis events for new wlroots

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,13 @@ verification that it has not changed on subsequent connections.
 Client certificates are now supported as well; simply place the certificate at
 `tls/cert`.
 
+#### wlroots wheel issues
+
+The latest version of wlroots has an issue where discrete axis events are 
+accumulated rather than sent directly; to correct for this the discrete
+parameter is now a multiple of `120` rather than `1`. For older wlroots
+versions experiencing abnormally-large scroll steps, set `wlr/wheel_mult` to `1`. 
+
 ## Acknowledgements
 I would like to thank
 * [uSynergy](https://github.com/symless/synergy-micro-client) for the protocol library

--- a/src/wl_input_wlr.c
+++ b/src/wl_input_wlr.c
@@ -2,10 +2,12 @@
 #include <stdbool.h>
 #include "log.h"
 #include "fdio_full.h"
+#include "config.h"
 #include <xkbcommon/xkbcommon.h>
 
 struct state_wlr {
 	struct zwlr_virtual_pointer_v1 *pointer;
+	int wheel_mult;
 	struct zwp_virtual_keyboard_v1 *keyboard;
 };
 
@@ -75,14 +77,14 @@ static void mouse_wheel(struct wlInput *input, signed short dx, signed short dy)
 	//we are a wheel, after all
 	zwlr_virtual_pointer_v1_axis_source(wlr->pointer, 0);
 	if (dx < 0) {
-		zwlr_virtual_pointer_v1_axis_discrete(wlr->pointer, wlTS(input->wl_ctx), 1, wl_fixed_from_int(15), 1);
+		zwlr_virtual_pointer_v1_axis_discrete(wlr->pointer, wlTS(input->wl_ctx), 1, wl_fixed_from_int(15), wlr->wheel_mult);
 	}else if (dx > 0) {
-		zwlr_virtual_pointer_v1_axis_discrete(wlr->pointer, wlTS(input->wl_ctx), 1, wl_fixed_from_int(-15), -1);
+		zwlr_virtual_pointer_v1_axis_discrete(wlr->pointer, wlTS(input->wl_ctx), 1, wl_fixed_from_int(-15), -1 * wlr->wheel_mult);
 	}
 	if (dy < 0) {
-		zwlr_virtual_pointer_v1_axis_discrete(wlr->pointer, wlTS(input->wl_ctx), 0, wl_fixed_from_int(15),1);
+		zwlr_virtual_pointer_v1_axis_discrete(wlr->pointer, wlTS(input->wl_ctx), 0, wl_fixed_from_int(15), wlr->wheel_mult);
 	} else if (dy > 0) {
-		zwlr_virtual_pointer_v1_axis_discrete(wlr->pointer, wlTS(input->wl_ctx), 0, wl_fixed_from_int(-15), -1);
+		zwlr_virtual_pointer_v1_axis_discrete(wlr->pointer, wlTS(input->wl_ctx), 0, wl_fixed_from_int(-15), -1 * wlr->wheel_mult);
 	}
 	zwlr_virtual_pointer_v1_frame(wlr->pointer);
 	wl_display_flush(input->wl_ctx->display);
@@ -97,7 +99,9 @@ bool wlInputInitWlr(struct wlContext *ctx)
 	}
 	wlr = xmalloc(sizeof(*wlr));
 	wlr->pointer = zwlr_virtual_pointer_manager_v1_create_virtual_pointer(ctx->pointer_manager, ctx->seat);
+
 	wlr->keyboard = zwp_virtual_keyboard_manager_v1_create_virtual_keyboard(ctx->keyboard_manager, ctx->seat);
+	wlr->wheel_mult = configTryLong("wlr/wheel_mult", 120);
 	ctx->input = (struct wlInput) {
 		.state = wlr,
 		.wl_ctx = ctx,


### PR DESCRIPTION
This allows for sane scrolling on latest wlroots git. As this breaks
older releases, `wlr/wheel_mult` is added to configuration, which
restores old behavior when set to `1`. Fixes #41