### PR TITLE
idle inhibition enable setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ move of 0,0 is sent (this is the default).
 The mouse approach prevents any clashes with keys, but will prevent cursor
 hiding.
 
+Synergy upstream seems to no longer support this; if your screenlocker never
+triggers set `idle-inhibit/enable` to `false`. Barrier and input-leap seem
+to still work. 
+
 #### TLS
 
 Enabled or disabled with `tls/enable`. Certificate hashes (for any given host) 

--- a/src/wl_idle.c
+++ b/src/wl_idle.c
@@ -17,7 +17,7 @@ static void on_idle_key(void *data, struct org_kde_kwin_idle_timeout *timeout)
 	if (idle_key_raw != -1) {
 		wlKeyRaw(ctx, idle_key_raw, true);
 		wlKeyRaw(ctx, idle_key_raw, false);
-	} else { 
+	} else {
 		wlKey(ctx, idle_key, 0, true);
 		wlKey(ctx, idle_key, 0, false);
 	}
@@ -37,7 +37,13 @@ void wlIdleInhibit(struct wlContext *ctx, bool on)
 	long idle_time;
 	char *idle_method;
 	char *idle_keyname;
+
 	logDbg("got idle inhibit request, state: %s", on ? "on" : "off");
+	if (!configTryBool("idle-inhibit/enable", true)) {
+		logDbg("idle inhibition disabled, ignoring request");
+		return;
+	}
+
 	if (!ctx->idle_manager) {
 		logWarn("Idle inhibit request, but no idle manager support");
 		return;


### PR DESCRIPTION
Synergy upstream no longer sends the screensaver sync messages, leading
to issues with screenlockers as in
https://github.com/r-c-f/waynergy/issues/49
so we add an `idle-inhibit/enable' bool option to enable or disable
inhibition. Barrier/input-leap still seem to support this feature and I
use it, so I'll default to leaving it on for now.