### PR TITLE
support gnome-session-inhibit for idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ move of 0,0 is sent (this is the default).
 The mouse approach prevents any clashes with keys, but will prevent cursor
 hiding.
 
+For GNOME, the `gnome` method will use `gnome-session-inhibit`, and is required for inhibition to work. This should be automatically detected if no method is set, based on compositor name. 
+
 Synergy upstream seems to no longer support this; if your screenlocker never
 triggers set `idle-inhibit/enable` to `false`. Barrier and input-leap seem
 to still work. 

--- a/src/sig.c
+++ b/src/sig.c
@@ -27,6 +27,8 @@ static void cleanup(void)
 	synNetDisconnect(&synNetContext);
 	logClose();
 	wlClose(&wlContext);
+	/* kill all related processes that remain alive */
+	kill(-1 * getpgid(getpid()), SIGTERM);
 	/*unmask any caught signals*/
 
 }


### PR DESCRIPTION
Support `idle-inhibit/method` `gnome`, which will use `gnome-session-inhibit` instead of the more usual idle manager protocol. Automatically default to this value when `gnome-shell` is detected as the compositor. Should fix #52