### PR TITLE
Fix EAGAIN (resource temporarily unavailable) wayland errors

### DIFF
--- a/doc/config-example/config.ini
+++ b/doc/config-example/config.ini
@@ -6,6 +6,8 @@ host = foo.bar
 #width = 1024
 #height = 768
 xkb_key_offset = 0
+# Restart on a fatal error, rather than exit
+#restart_on_fatal = false
 
 [screensaver]
 start = pkill -SIGUSR1 swayidle

--- a/doc/config-example/config.ini
+++ b/doc/config-example/config.ini
@@ -23,3 +23,7 @@ tofu = true
 level = 3
 mode = a
 path = /tmp/waynergy.log
+
+[wayland]
+# Timeout for display flushes (in ms), negative to block indefinitely
+#flush_timeout = 5000

--- a/include/log.h
+++ b/include/log.h
@@ -20,6 +20,7 @@ enum logLevel {
 enum logLevel logLevelFromString(const char *s);
 
 bool logInit(enum logLevel level, char *path);
+void logOutV(enum logLevel level, const char *fmt, va_list ap);
 void logOut(enum logLevel level, const char *fmt, ...);
 /* standard log functions */
 void logErr(const char *fmt, ...);

--- a/include/sig.h
+++ b/include/sig.h
@@ -11,6 +11,10 @@ extern volatile sig_atomic_t sigDoExit;
 extern volatile sig_atomic_t sigDoRestart;
 void Exit(int status);
 void Restart(void);
+/* exit or restart, for situations like wayland protocol errors beyond our
+ * control that don't necessarily mean the compositor no longer exists or the
+ * session actually ended */
+void ExitOrRestart(int status);
 void sigHandleInit(char **argv);
 void sigWaitSIGCHLD(bool state);
 

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -118,6 +118,7 @@ struct wlContext {
 	int width;
 	int height;
 	time_t epoch;
+	bool flush_pending;
 	//callbacks
 	void (*on_output_update)(struct wlContext *ctx);
 };

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -118,7 +118,7 @@ struct wlContext {
 	int width;
 	int height;
 	time_t epoch;
-	bool flush_pending;
+	long timeout;
 	//callbacks
 	void (*on_output_update)(struct wlContext *ctx);
 };

--- a/include/wayland.h
+++ b/include/wayland.h
@@ -122,6 +122,9 @@ struct wlContext {
 	void (*on_output_update)(struct wlContext *ctx);
 };
 
+/* flush the display with proper error checking */
+extern void wlDisplayFlush(struct wlContext *ctx);
+
 /* (re)set the keyboard layout according to the configuration
  * probably not useful outside wlSetup*/
 extern int wlKeySetConfigLayout(struct wlContext *ctx);

--- a/src/log.c
+++ b/src/log.c
@@ -80,7 +80,7 @@ static void log_out_v_(FILE *f, enum logLevel level, const char *fmt, va_list ap
 	fflush(f);
 	va_end(aq);
 }
-static void log_out_v(enum logLevel level, const char *fmt, va_list ap)
+void logOutV(enum logLevel level, const char *fmt, va_list ap)
 {
 	log_out_v_(stderr, level, fmt, ap);
 	if (log_file)
@@ -91,7 +91,7 @@ void logOut(enum logLevel level, const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	log_out_v(level, fmt, ap);
+	logOutV(level, fmt, ap);
 	va_end(ap);
 }
 
@@ -99,28 +99,28 @@ void logErr(const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	log_out_v(LOG_ERR, fmt, ap);
+	logOutV(LOG_ERR, fmt, ap);
 	va_end(ap);
 }
 void logWarn(const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	log_out_v(LOG_WARN, fmt, ap);
+	logOutV(LOG_WARN, fmt, ap);
 	va_end(ap);
 }
 void logInfo(const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	log_out_v(LOG_INFO, fmt, ap);
+	logOutV(LOG_INFO, fmt, ap);
 	va_end(ap);
 }
 void logDbg(const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	log_out_v(LOG_DBG, fmt, ap);
+	logOutV(LOG_DBG, fmt, ap);
 	va_end(ap);
 }
 bool logInit(enum logLevel level, char *path)

--- a/src/net.c
+++ b/src/net.c
@@ -226,6 +226,11 @@ void netPoll(struct synNetContext *snet_ctx, struct wlContext *wl_ctx)
 		/* ignore everything else until synergy is ready */
 		if (syn_ctx->m_connected) {
 			wlPollProc(wl_ctx, netPollFd[POLLFD_WL].revents);
+			if (wl_ctx->flush_pending) {
+				netPollFd[POLLFD_WL].events |= POLLOUT;
+			} else {
+				netPollFd[POLLFD_WL].events &= ~POLLOUT;
+			}
 			sigHandleRun();
 			clipMonitorPollProc(&netPollFd[POLLFD_CLIP_MON]);
 			sigHandleRun();

--- a/src/net.c
+++ b/src/net.c
@@ -226,11 +226,6 @@ void netPoll(struct synNetContext *snet_ctx, struct wlContext *wl_ctx)
 		/* ignore everything else until synergy is ready */
 		if (syn_ctx->m_connected) {
 			wlPollProc(wl_ctx, netPollFd[POLLFD_WL].revents);
-			if (wl_ctx->flush_pending) {
-				netPollFd[POLLFD_WL].events |= POLLOUT;
-			} else {
-				netPollFd[POLLFD_WL].events &= ~POLLOUT;
-			}
 			sigHandleRun();
 			clipMonitorPollProc(&netPollFd[POLLFD_CLIP_MON]);
 			sigHandleRun();

--- a/src/sig.c
+++ b/src/sig.c
@@ -44,6 +44,15 @@ void Restart(void)
 	exit(EXIT_FAILURE);
 }
 
+void ExitOrRestart(int status)
+{
+	if (configTryBool("restart_on_fatal", false)) {
+		logErr("Restarting on status %d", status);
+		Restart();
+	}
+	Exit(status);
+}
+
 static void sig_handle(int sig, siginfo_t *si, void *context)
 {
 	int level;

--- a/src/wayland.c
+++ b/src/wayland.c
@@ -38,7 +38,7 @@ void wlDisplayFlush(struct wlContext *ctx)
 
 	if ((error = wl_display_get_error(ctx->display))) {
 		logErr("Wayland display error %d: %s", error, display_strerror(error));
-		Exit(2);
+		ExitOrRestart(2);
 	}
 	wl_display_flush(ctx->display);
 }

--- a/src/wayland.c
+++ b/src/wayland.c
@@ -16,10 +16,6 @@
 #include "log.h"
 #include "sig.h"
 
-static void wl_log_handler(const char *fmt, va_list ap)
-{
-	logOutV(LOG_ERR, fmt, ap);
-}
 
 static char *display_strerror(int error)
 {
@@ -34,6 +30,14 @@ static char *display_strerror(int error)
 			return "compositor implementation error";
 	}
 	return strerror(error);
+}
+
+static void wl_log_handler(const char *fmt, va_list ap)
+{
+	logOutV(LOG_ERR, fmt, ap);
+	if (configTryBool("wayland_error_fatal", true)) {
+		ExitOrRestart(3);
+	}
 }
 
 static bool wl_display_flush_base(struct wlContext *ctx)

--- a/src/wayland.c
+++ b/src/wayland.c
@@ -16,6 +16,10 @@
 #include "log.h"
 #include "sig.h"
 
+static void wl_log_handler(const char *fmt, va_list ap)
+{
+	logOutV(LOG_ERR, fmt, ap);
+}
 
 static char *display_strerror(int error)
 {
@@ -447,6 +451,9 @@ bool wlSetup(struct wlContext *ctx, int width, int height, char *backend)
 {
 	int fd;
 	bool input_init = false;
+
+	wl_log_set_handler_client(&wl_log_handler);
+
 	ctx->width = width;
 	ctx->height = height;
 	ctx->display = wl_display_connect(NULL);

--- a/src/wayland.c
+++ b/src/wayland.c
@@ -17,6 +17,31 @@
 #include "sig.h"
 
 
+static char *display_strerror(int error)
+{
+	switch (error) {
+		case WL_DISPLAY_ERROR_INVALID_OBJECT:
+			return "server couldn't find object";
+		case WL_DISPLAY_ERROR_INVALID_METHOD:
+			return "method doesn't exist on specified interface or malformed request";
+		case WL_DISPLAY_ERROR_NO_MEMORY:
+			return "server is out of memory";
+		case WL_DISPLAY_ERROR_IMPLEMENTATION:
+			return "compositor implementation error";
+	}
+	return "unkown error";
+}
+
+void wlDisplayFlush(struct wlContext *ctx)
+{
+	int error;
+
+	if ((error = wl_display_get_error(ctx->display))) {
+		logErr("Wayland display error %d: %s", error, display_strerror(error));
+		Exit(2);
+	}
+	wl_display_flush(ctx->display);
+}
 
 void wlOutputAppend(struct wlOutput **outputs, struct wl_output *output, struct zxdg_output_v1 *xdg_output, uint32_t wl_name)
 {

--- a/src/wl_idle_kde.c
+++ b/src/wl_idle_kde.c
@@ -44,7 +44,7 @@ static void inhibit_start(struct wlIdle *idle)
 		return;
 	}
 	org_kde_kwin_idle_timeout_add_listener(kde->timeout, &kde->listener, idle);
-	wl_display_flush(idle->wl_ctx->display);
+	wlDisplayFlush(idle->wl_ctx);
 }
 
 static void inhibit_stop(struct wlIdle *idle)
@@ -56,7 +56,7 @@ static void inhibit_stop(struct wlIdle *idle)
 		return;
 	}
 	org_kde_kwin_idle_timeout_release(kde->timeout);
-	wl_display_flush(idle->wl_ctx->display);
+	wlDisplayFlush(idle->wl_ctx);
 	kde->timeout = NULL;
 }
 

--- a/src/wl_input_kde.c
+++ b/src/wl_input_kde.c
@@ -12,27 +12,27 @@ static void key(struct wlInput *input, int key, int state)
 {
 	struct org_kde_kwin_fake_input *fake = input->state;
 	org_kde_kwin_fake_input_keyboard_key(fake, key - 8, state);
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 static void mouse_rel_motion(struct wlInput *input, int dx, int dy)
 {
 	struct org_kde_kwin_fake_input *fake = input->state;
 	org_kde_kwin_fake_input_pointer_motion(fake, wl_fixed_from_int(dx), wl_fixed_from_int(dy));
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 
 static void mouse_motion(struct wlInput *input, int x, int y)
 {
 	struct org_kde_kwin_fake_input *fake = input->state;
 	org_kde_kwin_fake_input_pointer_motion_absolute(fake, wl_fixed_from_int(x), wl_fixed_from_int(y));
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 
 static void mouse_button(struct wlInput *input, int button, int state)
 {
 	struct org_kde_kwin_fake_input *fake = input->state;
 	org_kde_kwin_fake_input_button(fake, button, state);
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 
 static void mouse_wheel(struct wlInput *input, signed short dx, signed short dy)
@@ -48,7 +48,7 @@ static void mouse_wheel(struct wlInput *input, signed short dx, signed short dy)
 	} else if (dy > 0) {
 		org_kde_kwin_fake_input_axis(fake, 0, wl_fixed_from_int(-15));
 	}
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 
 bool wlInputInitKde(struct wlContext *ctx)

--- a/src/wl_input_wlr.c
+++ b/src/wl_input_wlr.c
@@ -41,7 +41,7 @@ static void key(struct wlInput *input, int key, int state)
 	xkb_layout_index_t group = xkb_state_serialize_layout(input->xkb_state, XKB_STATE_LAYOUT_EFFECTIVE);
 	zwp_virtual_keyboard_v1_key(wlr->keyboard, wlTS(input->wl_ctx), key - 8, state);
 	zwp_virtual_keyboard_v1_modifiers(wlr->keyboard, depressed, latched, locked, group);
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 
 static void mouse_rel_motion(struct wlInput *input, int dx, int dy)
@@ -49,21 +49,21 @@ static void mouse_rel_motion(struct wlInput *input, int dx, int dy)
 	struct state_wlr *wlr = input->state;
 	zwlr_virtual_pointer_v1_motion(wlr->pointer, wlTS(input->wl_ctx), wl_fixed_from_int(dx), wl_fixed_from_int(dy));
 	zwlr_virtual_pointer_v1_frame(wlr->pointer);
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 static void mouse_motion(struct wlInput *input, int x, int y)
 {
 	struct state_wlr *wlr = input->state;
 	zwlr_virtual_pointer_v1_motion_absolute(wlr->pointer, wlTS(input->wl_ctx), x, y, input->wl_ctx->width, input->wl_ctx->height);
 	zwlr_virtual_pointer_v1_frame(wlr->pointer);
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 static void mouse_button(struct wlInput *input, int button, int state)
 {
 	struct state_wlr *wlr = input->state;
 	zwlr_virtual_pointer_v1_button(wlr->pointer, wlTS(input->wl_ctx), button, state);
 	zwlr_virtual_pointer_v1_frame(wlr->pointer);
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 static void mouse_wheel(struct wlInput *input, signed short dx, signed short dy)
 {
@@ -81,7 +81,7 @@ static void mouse_wheel(struct wlInput *input, signed short dx, signed short dy)
 		zwlr_virtual_pointer_v1_axis_discrete(wlr->pointer, wlTS(input->wl_ctx), 0, wl_fixed_from_int(-15), -1 * wlr->wheel_mult);
 	}
 	zwlr_virtual_pointer_v1_frame(wlr->pointer);
-	wl_display_flush(input->wl_ctx->display);
+	wlDisplayFlush(input->wl_ctx);
 }
 
 size_t get_nums(size_t count, long *dst, char *buf)


### PR DESCRIPTION
Poll on wl_display_flush calls that fail with EAGAIN. Handle Wayland display errors better in general (log them properly, treat them with appropriate gravity, and allow reexecution when a fatal error occurs). Should fix #59 