### PR TITLE
feat: support mouse button 6&7

### DIFF
--- a/include/wayland.h
+++ b/include/wayland.h
@@ -52,7 +52,7 @@ struct wlIdle
 extern bool wlIdleInitKde(struct wlContext *ctx);
 extern bool wlIdleInitGnome(struct wlContext *ctx);
 
-#define WL_INPUT_BUTTON_COUNT 6
+#define WL_INPUT_BUTTON_COUNT 8
 
 struct wlInput {
 	/* module-specific state */

--- a/src/wl_input.c
+++ b/src/wl_input.c
@@ -19,6 +19,8 @@ void wlLoadButtonMap(struct wlContext *ctx)
 		0x111, /*BTN_RIGHT*/
 		0x113, /*BTN_SIDE*/
 		0x114, /*BTN_EXTRA*/
+		0x113, /*BTN_SIDE*/
+		0x114, /*BTN_EXTRA*/
 	};
 	static_assert(sizeof(default_map)/sizeof(*default_map) == WL_INPUT_BUTTON_COUNT, "button map size mismatch");
 	for (i = 0; i < WL_INPUT_BUTTON_COUNT; ++i) {


### PR DESCRIPTION
For mouse like Logi MX master3, the two side buttons are `Mouse button 6` and `Mouse button 7`.

This PR simply maps the two buttons to `BTN_SIDE` and `BTN_EXTRA`, and fix the issue that xwayland would crash when button 6 or 7 is clicked.