### PR TITLE
support updating input backend geometry

### DIFF
--- a/include/wayland.h
+++ b/include/wayland.h
@@ -83,6 +83,7 @@ struct wlInput {
 	void (*mouse_wheel)(struct wlInput *, signed short dx, signed short dy);
 	void (*key)(struct wlInput *, int, int);
 	bool (*key_map)(struct wlInput *, char *);
+	void (*update_geom)(struct wlInput *);
 };
 
 /* uinput must open device fds before privileges are dropped, so this is

--- a/src/wayland.c
+++ b/src/wayland.c
@@ -587,6 +587,11 @@ void wlResUpdate(struct wlContext *ctx, int width, int height)
 {
 	ctx->width = width;
 	ctx->height = height;
+	if (ctx->input.update_geom) {
+		ctx->input.update_geom(&ctx->input);
+	} else {
+		logDbg("Current output backend does not update input geometry");
+	}
 }
 
 int wlPrepareFd(struct wlContext *ctx)

--- a/src/wl_input_uinput.c
+++ b/src/wl_input_uinput.c
@@ -186,6 +186,21 @@ static bool init_mouse(struct wlContext *ctx, struct state_uinput *ui, int max_x
 	return true;
 }
 
+static bool reinit_mouse(struct wlInput *input)
+{
+	struct state_uinput *ui = input->state;
+	TRY_IOCTL0(ui->mouse_fd, UI_DEV_DESTROY);
+	return init_mouse(input->wl_ctx, ui, input->wl_ctx->width, input->wl_ctx->height);
+}
+
+static void update_geom(struct wlInput *input)
+{
+	logDbg("uinput: updating geometry for mouse");
+	if (!reinit_mouse(input)) {
+		logErr("Could not reinitialize uinput for mouse");
+	}
+}
+
 bool wlInputInitUinput(struct wlContext *ctx)
 {
 	struct state_uinput *ui;
@@ -213,6 +228,7 @@ bool wlInputInitUinput(struct wlContext *ctx)
 		.mouse_wheel = mouse_wheel,
 		.key = key,
 		.key_map = key_map,
+		.update_geom = update_geom,
 	};
 	wlLoadButtonMap(ctx);
 


### PR DESCRIPTION
uinput in particular seems to be badly behaved when an output is lost or gained, as the scale for absolute mouse position is not normally changed. This adds an optional function for the input module, and an implementation for uinput to solve this issue originally reported on IRC.