### PR TITLE
Update hostname on each connection attempt

### DIFF
--- a/include/uSynergy.h
+++ b/include/uSynergy.h
@@ -331,7 +331,8 @@ typedef struct uSynergyContext
 	uSynergyReceiveFunc				m_receiveFunc;									/* Receive data function */
 	uSynergySleepFunc				m_sleepFunc;									/* Thread sleep function */
 	uSynergyGetTimeFunc				m_getTimeFunc;									/* Get current time function */
-	const char*						m_clientName;									/* Name of Synergy Screen / Client */
+	char*						m_clientName;									/* Name of Synergy Screen / Client */
+	bool 							m_clientAutoName; 								/* whether to set name on each connection attempt from hostname */
 	uint16_t						m_clientWidth;									/* Width of screen */
 	uint16_t						m_clientHeight;									/* Height of screen */
 

--- a/src/uSynergy.c
+++ b/src/uSynergy.c
@@ -333,6 +333,17 @@ static void sProcessMessage(uSynergyContext *context, struct sspBuf *msg)
 		}
 		logInfo("Server is %s %" PRIu16 ".%" PRIu16, imp, server_major, server_minor);
 
+		// If we have autoname enabled, update the name from the hostname.
+		// This allows us to handle hostname changes due to late network
+		// setup in some cases (see #104)
+		if (context->m_clientAutoName) {
+			if (gethostname(context->m_clientName, _POSIX_HOST_NAME_MAX - 1) == -1) {
+				logPErr("Updating gethostname() failed");
+				REPLY_ERROR();
+			}
+			logDbg("Updated name to %s", context->m_clientName);
+		}
+
 		// Initialize position in reply buffer -- discards leftovers from
 		// failed send attempts, ensures no protocol errors on initialization
 		context->m_replyCur = context->m_replyBuffer+4;


### PR DESCRIPTION
Per #104, some users are setting hostname via dhcp, which may be delayed, and desktop environment autostart doesn't necessarily allow for accounting for this. So call gethostname() on connection, rather than on startup.