### PR TITLE
Only handle clipboard after hello response is received

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -233,7 +233,7 @@ void netPoll(struct synNetContext *snet_ctx, struct wlContext *wl_ctx)
 		if (syn_ctx->m_connected) {
 			wlPollProc(wl_ctx, netPollFd[POLLFD_WL].revents);
 			sigHandleRun();
-			if (syn_ctx->m_hasReceivedHello) {
+			if (syn_ctx->m_hasReceivedHello && syn_ctx->m_infoCurrent) {
 				clipMonitorPollProc(&netPollFd[POLLFD_CLIP_MON]);
 				sigHandleRun();
 				for (int i = POLLFD_CLIP_UPDATER; i < POLLFD_COUNT; ++i) {

--- a/src/net.c
+++ b/src/net.c
@@ -233,11 +233,13 @@ void netPoll(struct synNetContext *snet_ctx, struct wlContext *wl_ctx)
 		if (syn_ctx->m_connected) {
 			wlPollProc(wl_ctx, netPollFd[POLLFD_WL].revents);
 			sigHandleRun();
-			clipMonitorPollProc(&netPollFd[POLLFD_CLIP_MON]);
-			sigHandleRun();
-			for (int i = POLLFD_CLIP_UPDATER; i < POLLFD_COUNT; ++i) {
-				clipMonitorPollProc(netPollFd + i);
+			if (syn_ctx->m_hasReceivedHello) {
+				clipMonitorPollProc(&netPollFd[POLLFD_CLIP_MON]);
 				sigHandleRun();
+				for (int i = POLLFD_CLIP_UPDATER; i < POLLFD_COUNT; ++i) {
+					clipMonitorPollProc(netPollFd + i);
+					sigHandleRun();
+				}
 			}
 		}
 		nfd = syn_ctx->m_connected ? POLLFD_COUNT : 1;


### PR DESCRIPTION
Fixes #34 as I was able to reproduce it via unexpected clipboard events.

Connection now happens immediately, without a 10s timeout and connection retry.

Client logs after this change show clipboard handling occurring only after the full connection is established:

```
0.022662311: [INFO] Using ext-idle-notify-v1 idle inhibition protocol
0.022664425: [DEBUG] Got idle inhibit request: on
0.022672039: [INFO] Going to connect to 192.168.1.10 at port 24800
0.027387552: [DEBUG] Property hash/192.168.1.10 not found in INI
0.102538704: [INFO] Server is Synergy 1.8
0.102572497: [INFO] Connected as client "client-name"
0.102574671: [DEBUG] Accepting
0.102586103: [DEBUG] Accepting
0.102595591: [DEBUG] Clipboard data read for c: 39 bytes
0.102614436: [DEBUG] Clipboard data read for p: 39 bytes
3.198709880: [DEBUG] Got CALV
```