### PR TITLE
wl_input: fix indefinite hang on startup when a compositor keymap event never arrives

### DIFF
--- a/include/wayland.h
+++ b/include/wayland.h
@@ -8,6 +8,7 @@
 #include "os.h"
 #include "xmem.h"
 #include "config.h"
+#include "xkb_util.h"
 #include <unistd.h>
 #include <wayland-client.h>
 #include <wayland-client-protocol.h>

--- a/include/xkb_util.h
+++ b/include/xkb_util.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <stdbool.h>
+#include <xkbcommon/xkbcommon.h>
+
+/* src/xkb_util.c. Split out of wayland.h/wl_input.c specifically so
+ * these have no Wayland-protocol dependency and can be included and
+ * linked (see test/keymap.c) without any of the generated protocol
+ * headers, which only exist inside the meson build tree and aren't
+ * available to the plain `cc` invocations in test/run.sh. */
+
+/* Baked-in fallback keymap, used when the compositor's own keymap could
+ * not be obtained (either because wl_keyboard_map is set to false, or
+ * because fetching/mmap'ing it from the compositor failed) and no
+ * explicit xkb_keymap has been configured. Equivalent to what
+ * `setxkbmap -print` emits for a stock US/evdev layout. This exists so
+ * ctx->kb_map being NULL never reaches xkb_keymap_new_from_string() as a
+ * NULL keymap string -- see wlKeySetConfigLayout() in wl_input.c.
+ */
+extern const char *waynergyDefaultKeymap;
+
+/* Keyboard state tracking for modifier masks (the synergy protocol is
+ * less than ideal at sending us modifiers). On success, *out_ctx,
+ * *out_map, and *out_state are all populated and owned by the caller;
+ * on failure they're left NULL and nothing needs cleaning up. */
+extern bool waynergyModInit(struct xkb_context **out_ctx,
+		struct xkb_keymap **out_map, struct xkb_state **out_state,
+		char *keymap_str);

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ src_c = files(
   'src/wl_idle_kde.c',
   'src/wl_idle_ext.c',
   'src/wl_input.c',
+  'src/xkb_util.c',
   'src/wl_input_wlr.c',
   'src/wl_input_kde.c',
   'src/wl_input_uinput.c',

--- a/src/wl_input.c
+++ b/src/wl_input.c
@@ -5,7 +5,6 @@
 #include "fdio_full.h"
 #include <xkbcommon/xkbcommon.h>
 
-
 /* handle button maps */
 
 void wlLoadButtonMap(struct wlContext *ctx)
@@ -32,29 +31,9 @@ void wlLoadButtonMap(struct wlContext *ctx)
 };
 
 
-/* Code to track keyboard state for modifier masks
- * because the synergy protocol is less than ideal at sending us modifiers
-*/
-
-
-static bool local_mod_init(struct wlContext *wl_ctx, char *keymap_str) {
-	wl_ctx->input.xkb_ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-	if (!wl_ctx->input.xkb_ctx) {
-		return false;
-	}
-	wl_ctx->input.xkb_map = xkb_keymap_new_from_string(wl_ctx->input.xkb_ctx, keymap_str, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
-	if (!wl_ctx->input.xkb_map) {
-		xkb_context_unref(wl_ctx->input.xkb_ctx);
-		return false;
-	}
-	wl_ctx->input.xkb_state = xkb_state_new(wl_ctx->input.xkb_map);
-	if (!wl_ctx->input.xkb_state) {
-		xkb_map_unref(wl_ctx->input.xkb_map);
-		xkb_context_unref(wl_ctx->input.xkb_ctx);
-		return false;
-	}
-	return true;
-}
+/* Keyboard state tracking for modifier masks (the synergy protocol is
+ * less than ideal at sending us modifiers) starts with waynergyModInit(),
+ * in src/xkb_util.c, declared in wayland.h. */
 
 /* and code to handle raw mapping of keys */
 
@@ -178,17 +157,50 @@ int wlKeySetConfigLayout(struct wlContext *ctx)
 {
 	int ret = 0;
 
-	/* ensure that we've given everything a chance to give us a proper
-	   default */
+	/* Give the compositor's keymap event a chance to arrive if it
+	 * hasn't already (ctx->kb_map is only ever set by keyboard_keymap()
+	 * in wayland.c). A raw wl_display_dispatch() call has no place
+	 * here: it blocks until *some* event arrives, and ctx->kb_map can
+	 * legitimately stay unset for reasons that mean no such event is
+	 * ever coming -- wl_keyboard_map=false, a failed mmap() of the
+	 * keymap fd, or the seat never advertising keyboard capability at
+	 * all (in which case keyboard_keymap() is never even registered as
+	 * a listener) -- so dispatch() alone can hang indefinitely.
+	 * wl_display_roundtrip() doesn't have that problem: the Wayland
+	 * core protocol requires the server to respond to wl_display.sync
+	 * regardless of what else is or isn't pending, so it's bounded no
+	 * matter which of the above applies, and it already dispatches
+	 * anything that is pending (a keymap event included, if one's
+	 * genuinely queued) on its way to that guaranteed response. */
 	if (!ctx->kb_map) {
-		wl_display_dispatch(ctx->display);
 		wl_display_roundtrip(ctx->display);
 	}
 
-	char *default_map = ctx->kb_map;
+	/* ctx->kb_map can be unset for any of the reasons noted above, so
+	 * fall back to a real baked-in keymap rather than leaving
+	 * default_map (and, absent an explicit xkb_keymap config,
+	 * keymap_str below) NULL -- that reaches xkb_keymap_new_from_string()
+	 * as a NULL string, which is a crash. This also matches what the
+	 * README already claims happens here. */
+	char *default_map = ctx->kb_map ? ctx->kb_map : (char *)waynergyDefaultKeymap;
 	logDbg("Will default to map %s", default_map);
 	char *keymap_str = configTryStringFull("xkb_keymap", default_map);
-	local_mod_init(ctx, keymap_str);
+	/* default_map is never NULL (see above), and configTryStringFull()
+	 * only returns NULL when its default arg is -- so this genuinely
+	 * can't fail, not just "shouldn't". An assert documents that as an
+	 * enforced invariant instead of a dead runtime branch that can
+	 * never actually run. */
+	assert(keymap_str);
+	if (!waynergyModInit(&ctx->input.xkb_ctx, &ctx->input.xkb_map, &ctx->input.xkb_state, keymap_str)) {
+		/* xkb_state would otherwise stay NULL while setup carries on
+		 * as if nothing were wrong -- the first keypress then reaches
+		 * xkb_state_update_key()/xkb_state_serialize_mods() in
+		 * wlKeyRaw() with a NULL state and crashes there instead of
+		 * failing cleanly here at startup. */
+		logErr("Failed to parse keymap, cannot track modifier state");
+		free(keymap_str);
+		return 1;
+	}
 	ret = !ctx->input.key_map(&ctx->input, keymap_str);
 	ctx->input.key_press_state_len = 0;
 	load_raw_keymap(ctx);

--- a/src/xkb_util.c
+++ b/src/xkb_util.c
@@ -1,0 +1,50 @@
+/* See include/xkb_util.h for why this is split out of wayland.h/
+ * wl_input.c: no Wayland-protocol dependency, so it (and its declarations)
+ * can be included and linked directly by test/keymap.c, using the same
+ * plain `cc` invocation as the rest of this project's minimal test
+ * harness (test/run.sh) -- unlike wayland.h, which pulls in generated
+ * protocol headers only available inside the meson build tree.
+ */
+#include "xkb_util.h"
+
+const char *waynergyDefaultKeymap =
+	"xkb_keymap {\n"
+	"	xkb_keycodes  { include \"evdev+aliases(qwerty)\" };\n"
+	"	xkb_types     { include \"complete\" };\n"
+	"	xkb_compat    { include \"complete\" };\n"
+	"	xkb_symbols   { include \"pc+us+inet(evdev)\" };\n"
+	"};\n";
+
+bool waynergyModInit(struct xkb_context **out_ctx, struct xkb_keymap **out_map,
+		struct xkb_state **out_state, char *keymap_str)
+{
+	/* Set all three up front so every failure path below honors the
+	 * "left NULL on failure" contract documented in xkb_util.h, even
+	 * the first one, which returns before out_map/out_state are
+	 * otherwise touched. A caller that reuses these across a retry
+	 * without re-zeroing them itself could otherwise misread leftover
+	 * non-NULL values as still valid, or double-free them. */
+	*out_ctx = NULL;
+	*out_map = NULL;
+	*out_state = NULL;
+
+	*out_ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	if (!*out_ctx) {
+		return false;
+	}
+	*out_map = xkb_keymap_new_from_string(*out_ctx, keymap_str, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	if (!*out_map) {
+		xkb_context_unref(*out_ctx);
+		*out_ctx = NULL;
+		return false;
+	}
+	*out_state = xkb_state_new(*out_map);
+	if (!*out_state) {
+		xkb_map_unref(*out_map);
+		*out_map = NULL;
+		xkb_context_unref(*out_ctx);
+		*out_ctx = NULL;
+		return false;
+	}
+	return true;
+}

--- a/test/keymap.c
+++ b/test/keymap.c
@@ -1,0 +1,113 @@
+#include "../include/xkb_util.h"
+#include "../include/log.h"
+
+/* Covers two things wlKeySetConfigLayout() (src/wl_input.c) depends on:
+ * that waynergyDefaultKeymap is valid xkb, and that waynergyModInit()
+ * correctly reports success/failure (its caller relies on that return
+ * value to fail cleanly on an unparseable keymap rather than continuing
+ * with a NULL xkb_state, which wlKeyRaw() would later crash on).
+ *
+ * Doesn't cover wlKeySetConfigLayout() itself, or the
+ * wl_display_roundtrip() call it makes to give a compositor keymap event
+ * a chance to arrive -- that's entangled with a live Wayland connection,
+ * outside what this project's existing test harness attempts (see
+ * test/os.c, test/config.c: pure logic only, no compositor).
+ */
+
+static bool default_keymap_compiles(void)
+{
+	struct xkb_context *ctx;
+	struct xkb_keymap *km;
+	bool ok;
+
+	if (!(ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS))) {
+		logErr("Could not create xkb context");
+		return false;
+	}
+	km = xkb_keymap_new_from_string(ctx, waynergyDefaultKeymap,
+			XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	ok = (km != NULL);
+	if (!ok) {
+		logErr("waynergyDefaultKeymap failed to compile");
+	}
+	if (km) {
+		xkb_keymap_unref(km);
+	}
+	xkb_context_unref(ctx);
+	return ok;
+}
+
+static bool malformed_keymap_rejected(void)
+{
+	struct xkb_context *ctx;
+	struct xkb_keymap *km;
+	bool ok;
+	const char *bad = "this is not a valid xkb keymap {{{";
+
+	if (!(ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS))) {
+		logErr("Could not create xkb context");
+		return false;
+	}
+	km = xkb_keymap_new_from_string(ctx, bad,
+			XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	ok = (km == NULL);
+	if (!ok) {
+		logErr("malformed keymap string was incorrectly accepted");
+		xkb_keymap_unref(km);
+	}
+	xkb_context_unref(ctx);
+	return ok;
+}
+
+static bool mod_init_succeeds_on_valid_keymap(void)
+{
+	struct xkb_context *xkb_ctx = NULL;
+	struct xkb_keymap *xkb_map = NULL;
+	struct xkb_state *xkb_state = NULL;
+	bool ok;
+
+	ok = waynergyModInit(&xkb_ctx, &xkb_map, &xkb_state, (char *)waynergyDefaultKeymap);
+	if (!ok) {
+		logErr("waynergyModInit() failed on a known-valid keymap");
+		return false;
+	}
+	if (!xkb_state) {
+		logErr("waynergyModInit() returned true but left xkb_state NULL");
+		return false;
+	}
+	xkb_state_unref(xkb_state);
+	xkb_keymap_unref(xkb_map);
+	xkb_context_unref(xkb_ctx);
+	return true;
+}
+
+static bool mod_init_fails_on_malformed_keymap(void)
+{
+	struct xkb_context *xkb_ctx = NULL;
+	struct xkb_keymap *xkb_map = NULL;
+	struct xkb_state *xkb_state = NULL;
+	bool ok;
+
+	ok = waynergyModInit(&xkb_ctx, &xkb_map, &xkb_state, "this is not a valid xkb keymap {{{");
+	if (ok) {
+		logErr("waynergyModInit() incorrectly succeeded on a malformed keymap");
+		return false;
+	}
+	if (xkb_state) {
+		logErr("waynergyModInit() returned false but xkb_state is non-NULL anyway");
+		return false;
+	}
+	return true;
+}
+
+int main(int argc, char **argv)
+{
+	logInit(LOG_DBG, NULL);
+
+	bool stat = true;
+	stat = stat && default_keymap_compiles();
+	stat = stat && malformed_keymap_rejected();
+	stat = stat && mod_init_succeeds_on_valid_keymap();
+	stat = stat && mod_init_fails_on_malformed_keymap();
+	return !stat;
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,11 +1,22 @@
 #!/bin/sh
 
+# Note: previously each `cc` invocation and its `if ./a.out` check were
+# separate statements, so a failed compile (cc exiting non-zero, leaving
+# a.out untouched) would silently re-run and report on the *previous*
+# test's stale binary instead of failing. Removing any leftover a.out
+# before each compile is enough to fix that: on failure there's then
+# nothing left to run, and `./a.out` on a missing file already fails on
+# its own, same as any other test failure below.
+
+rm -f a.out
+
 cc -D_GNU_SOURCE -DWAYNERGY_TEST -g -I../include os.c ../src/os.c ../src/log.c
 if ./a.out; then
 	echo "os.c: passed"
 else
 	echo "os.c: failed"
 fi
+rm -f a.out
 
 cc -D_GNU_SOURCE -DWAYNERGY_TEST -g -I../include config.c ../src/os.c ../src/log.c ../src/config.c
 if ./a.out; then
@@ -13,3 +24,12 @@ if ./a.out; then
 else
 	echo "config.c: failed"
 fi
+rm -f a.out
+
+cc -D_GNU_SOURCE -DWAYNERGY_TEST -g -I../include keymap.c ../src/xkb_util.c ../src/log.c -lxkbcommon
+if ./a.out; then
+	echo "keymap.c: passed"
+else
+	echo "keymap.c: failed"
+fi
+rm -f a.out


### PR DESCRIPTION
This PR addresses an issue I found when trying to find the right key mapping between my MacOS synergy server and a waynergy client. Claude drafted a fix; its notes are below. I'm happy to do any reworks that would be helpful. Thank you for maintaining this software.

# wl_keyboard_map=false hangs waynergy indefinitely at startup

*(Supersedes #113, closed unintentionally when its fork was deleted —
GitHub won't let a PR reopen onto a recreated fork of the same name,
even with the same commit. Same commit, same content, just a fresh PR
number.)*

## Summary

Setting `wl_keyboard_map = false` in `config.ini` — documented as
"falling back on a baked-in default" keymap — instead makes waynergy
hang indefinitely during startup, right after logging `"Using wlroots
virtual input protocols"`. It never reaches the connection stage, and
doesn't respond to `SIGTERM` (a `systemctl stop` on a unit running it
had to escalate to `SIGABRT` to kill it; a bare `timeout N` needs
`-k` to actually terminate it).

## Root cause

`wlKeySetConfigLayout()` in `src/wl_input.c` unconditionally called
`wl_display_dispatch()` whenever `ctx->kb_map` was `NULL`, on the
assumption that a compositor keymap event was still pending:

```c
if (!ctx->kb_map) {
	wl_display_dispatch(ctx->display);
	wl_display_roundtrip(ctx->display);
}
```

But `ctx->kb_map` is only ever set by `keyboard_keymap()`
(`src/wayland.c`), and it can legitimately never fire at all:

- `wl_keyboard_map=false` makes it take an early return without
  setting `kb_map`.
- `mmap()`'ing the compositor's keymap fd can simply fail.
- The seat may never advertise keyboard capability in the first
  place, in which case `keyboard_keymap()` is never even registered
  as a listener (`seat_capabilities()` only calls
  `wl_keyboard_add_listener()` when `WL_SEAT_CAPABILITY_KEYBOARD` is
  set).

In any of those cases, the unconditional `wl_display_dispatch()` call
blocks forever waiting for an event that isn't coming — confirmed via
`/proc/<pid>/wchan`: `poll_schedule_timeout`.

`wl_display_roundtrip()` alone doesn't have this problem: the Wayland
core protocol requires the server to respond to `wl_display.sync`
regardless of what else is or isn't pending, so it's bounded no
matter which of the above applies, and it already dispatches anything
that is pending — a keymap event included, if one's genuinely queued
— on its way to that guaranteed response. The fix drops the preceding
`dispatch()` call rather than trying to enumerate the specific reasons
a keymap event might never arrive.

## Secondary issue: no actual baked-in default existed

Separately (and reachable even with `wl_keyboard_map` at its default
`true`, e.g. via the `mmap()` failure above): `default_map` was just
`ctx->kb_map` with no fallback at all. If it was `NULL` and no
`xkb_keymap` was configured, a `NULL` keymap string reached
`xkb_keymap_new_from_string()` — hit independently as a segfault after
some earlier crashed waynergy processes had left the compositor's
keymap state unusual. The README's claim of "falling back on a
baked-in default" didn't correspond to anything in the code — there
was no baked-in default keymap string anywhere in the source.

## Fix

- Drop the `wl_display_dispatch()` call; `wl_display_roundtrip()`
  alone is sufficient and bounded (see above).
- Add an actual baked-in default keymap (a standard `evdev+us` keymap,
  equivalent to what `setxkbmap -print` emits by default), in a new
  `src/xkb_util.c`, and fall back to it when no compositor keymap is
  available — delivering on what the docs already claim.
- Moved `waynergyModInit()` (formerly `static local_mod_init()` in
  `wl_input.c`) into `src/xkb_util.c` alongside the default keymap,
  and decoupled it from `struct wlContext` — it only ever touched
  three xkbcommon fields, so it now takes
  `xkb_context`/`xkb_keymap`/`xkb_state` out-parameters directly.
  Declared once in a new `include/xkb_util.h`. Its return value is now
  checked at the call site: a keymap that fails to parse used to leave
  `xkb_state` silently `NULL` while setup continued as normal, reaching
  a NULL-dereferencing crash in `wlKeyRaw()` on the first keypress
  instead of failing cleanly at startup. All three out-parameters are
  also unconditionally zeroed on entry, so every failure path honors
  the "left NULL on failure" contract this is documented as having.
- Added `test/keymap.c`, in the same plain-C, no-framework style as
  this project's existing `test/os.c`/`test/config.c` (run via
  `test/run.sh`, no CI, no meson integration — matching this project's
  existing conventions, which don't extend that far for anything
  else either): confirms the fallback keymap compiles, that a
  malformed one is rejected, and calls `waynergyModInit()` directly
  with both to check its actual return value and output state.
- Fixed a bug in `test/run.sh` found while adding that test: it ran
  each `cc` invocation and its `if ./a.out` check as separate
  statements, so a failed compile (`a.out` left untouched) would
  silently re-run and report on the *previous* test's stale binary
  instead of failing. Removing any leftover `a.out` before each
  compile fixes that.

## Verification

Built against current `master` in an isolated toolbox container,
tested live against a real sway session:

- **Before the fix**, `wl_keyboard_map=false` with no `xkb_keymap`
  configured: hangs indefinitely after `"Using wlroots virtual input
  protocols"`, requires `SIGKILL`.
- **After the fix**, same config: proceeds normally past setup into
  the connection-retry loop.
- A deliberately malformed `xkb_keymap` now fails cleanly at startup
  (logged error, clean exit) instead of crashing.
- **Regression check**: default config (`wl_keyboard_map` unset)
  still correctly fetches and uses the real compositor keymap, no
  behavior change.
- Full `test/run.sh` passes, including a deliberate compile-failure
  check confirming it now reports failure correctly instead of a
  stale pass.
